### PR TITLE
fix tracking so that all arguments are contained in command key

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { awsPromptLoop } from './prompts/aws_help'
 import { awsSetup } from './utils/awsCreds'
 import { execPowerMode } from './utils/powerUser'
 import { argv } from './types/argvs'
-import { track, startTimer, endTimer } from './utils/track'
+import { track, startTimer, getTotalTime } from './utils/track'
 
 const logo = `█▀▀ ▀▀█▀▀ █▀▀█   █▀▀█ ░▀░   █▀▀█ █░░░█ █▀▀   █▀▀█ █▀▀█
 █░░ ░░█░░ █░░█   █▄▄█ ▀█▀   █▄▄█ █▄█▄█ ▀▀█   █░░█ █░░█
@@ -77,16 +77,8 @@ const main = async () => {
   )
   try {
     await createPipeline({})
-    const endTime = endTimer()
-    const totalTime = endTime - startTime
-    const metadata = {
-      totalTime: `${totalTime} seconds`,
-      isDone: true,
-    }
-    track(metadata)
   } catch (err) {
-    const endTime = endTimer()
-    const totalTime = endTime - startTime
+    const totalTime = getTotalTime()
     const metadata = {
       totalTime: `${totalTime} seconds`,
       error: err,

--- a/src/prompts/aws_help.ts
+++ b/src/prompts/aws_help.ts
@@ -16,7 +16,7 @@ export const awsPromptLoop = async (
     async (result: manObj) => {
       const metadata = {
         awsHelp: `aws ${service}${command} help`,
-        isDone: false
+        isDone: false,
       }
       track(metadata)
 

--- a/src/prompts/aws_help.ts
+++ b/src/prompts/aws_help.ts
@@ -4,7 +4,7 @@ import { manObj } from '../types/aws'
 import { checkForCommands } from '../utils/helpers'
 import { BACK_COMMAND } from '../constants/aws'
 import { outputAWS } from '../output'
-import { track } from '../utils/track'
+import { track, getTotalTime } from '../utils/track'
 
 // recursive solution for aws cli loop
 export const awsPromptLoop = async (
@@ -14,6 +14,7 @@ export const awsPromptLoop = async (
 ) => {
   return execMan(`aws ${service}${command} help`).then(
     async (result: manObj) => {
+      let commandhistory = `aws ${service}${command}`
       const metadata = {
         awsHelp: `aws ${service}${command} help`,
         isDone: false,
@@ -28,7 +29,15 @@ export const awsPromptLoop = async (
         return awsPromptLoop(service, history.pop() || '', history)
       }
       // Recursive exit condition
+
       if (!output) {
+        const totalTime = getTotalTime()
+        const metadata = {
+          totalTime: `${totalTime} seconds`,
+          isDone: true,
+          awsHelp: commandhistory,
+        }
+        track(metadata)
         return newCommand
       }
       history.push(command)

--- a/src/utils/track.ts
+++ b/src/utils/track.ts
@@ -22,15 +22,26 @@ export const track = async (metadata: metadata) => {
     trackedData['command'] = trackedData.awsHelp
       .split(' ')
       .filter(el => el !== '')
+    trackedData['powerUserArgs'] = ['aws', ...sdk.yargs.argv._]
     delete trackedData.awsHelp
   }
   sdk.track(['track', 'aws'], trackedData)
 }
 
+let startTime
+let endTime
+
 export const startTimer = (): number => {
-  return process.hrtime()[0]
+  startTime = process.hrtime()[0]
+  return startTime
 }
 
 export const endTimer = (): number => {
-  return process.hrtime()[0]
+  endTime = process.hrtime()[0]
+  return endTime
+}
+
+export const getTotalTime = (): number => {
+  endTimer()
+  return endTime - startTime
 }

--- a/src/utils/track.ts
+++ b/src/utils/track.ts
@@ -1,27 +1,30 @@
 import { sdk } from '@cto.ai/sdk'
 
-/*
- - user info
- - command 
- - error messages
- - time spent in ops
- - did user finish ops?
-*/
-
 interface metadata {
   error?: string
   totalTime?: string
+  awsHelp?: string
   isDone: boolean
 }
 
 export const track = async (metadata: metadata) => {
-  sdk.track(['track', 'aws'], {
+  const trackedData = {
     user: await sdk.user(),
     os: sdk.getHostOS(),
     isContainer: sdk.isContainer(),
     command: ['aws', ...sdk.yargs.argv._],
     ...metadata,
-  })
+  }
+  if (trackedData.command.length === 1) {
+    delete trackedData.command
+  }
+  if ('awsHelp' in metadata) {
+    trackedData['command'] = trackedData.awsHelp
+      .split(' ')
+      .filter(el => el !== '')
+    delete trackedData.awsHelp
+  }
+  sdk.track(['track', 'aws'], trackedData)
 }
 
 export const startTimer = (): number => {


### PR DESCRIPTION
Tracking metadata had separate key called `awsHelp` that contains aws args when op is used interactively.

Now `command` key in tracking metadata will always contain aws arguments regardless of power mode or interactive mode to add simplicity

Also added `powerUserArgs` Key to capture cli passed args

now final call is captured in `command` as well

![image](https://user-images.githubusercontent.com/19717602/68246383-866a4200-ffcd-11e9-9b7f-0f0bc5b1c8ae.png)
